### PR TITLE
Feat: add `overlayColor` option to Boarding class

### DIFF
--- a/index.html
+++ b/index.html
@@ -642,11 +642,11 @@ boarding.start();
           <pre><code class="javascript">const boarding = new Boarding({
   className: 'scoped-class', // className to wrap boarding.js popover
   animate: true, // Animate while changing highlighted element
-  opacity: 0.75, // Background opacity (0 means only popovers and without overlay)
+  opacity: 0.75, // Overlay opacity (0 means only popovers and without overlay)
   padding: 10, // Distance of element from around the edges
   allowClose: true, // Whether clicking on overlay should close or not
   overlayClickNext: false, // Should it move to next step on overlay click
-  overlayColor: 'rgb(0,0,0)', // Background color for the overlay element
+  overlayColor: 'rgb(0,0,0)', // Fill color for the overlay
   doneBtnText: 'Done', // Text on the final button
   closeBtnText: 'Close', // Text on the close button for this step
   nextBtnText: 'Next', // Next button text for this step

--- a/index.html
+++ b/index.html
@@ -646,6 +646,7 @@ boarding.start();
   padding: 10, // Distance of element from around the edges
   allowClose: true, // Whether clicking on overlay should close or not
   overlayClickNext: false, // Should it move to next step on overlay click
+  overlayColor: 'rgb(0,0,0)', // Background color for the overlay element
   doneBtnText: 'Done', // Text on the final button
   closeBtnText: 'Close', // Text on the close button for this step
   nextBtnText: 'Next', // Next button text for this step

--- a/readme.md
+++ b/readme.md
@@ -260,11 +260,11 @@ Here are the options that Boarding understands:
 const boarding = new Boarding({
   className: "scoped-class", // className to wrap boarding.js popover
   animate: true, // Whether to animate or not
-  opacity: 0.75, // Background opacity (0 means only popovers and without overlay)
+  opacity: 0.75, // Overlay opacity (0 means only popovers and without overlay)
   padding: 10, // Distance of element from around the edges
   allowClose: true, // Whether the click on overlay should close or not
   overlayClickNext: false, // Whether the click on overlay should move next
-  overlayColor: "rgb(0,0,0)", // Background color for the overlay element
+  overlayColor: "rgb(0,0,0)", // Fill color for the overlay
   doneBtnText: "Done", // Text on the final button
   closeBtnText: "Close", // Text on the close button for this step
   nextBtnText: "Next", // Next button text for this step

--- a/readme.md
+++ b/readme.md
@@ -264,6 +264,7 @@ const boarding = new Boarding({
   padding: 10, // Distance of element from around the edges
   allowClose: true, // Whether the click on overlay should close or not
   overlayClickNext: false, // Whether the click on overlay should move next
+  overlayColor: "rgb(0,0,0)", // Background color for the overlay element
   doneBtnText: "Done", // Text on the final button
   closeBtnText: "Close", // Text on the close button for this step
   nextBtnText: "Next", // Next button text for this step

--- a/src/lib/boarding.ts
+++ b/src/lib/boarding.ts
@@ -104,6 +104,7 @@ class Boarding {
       radius: this.options.radius,
       onReset: this.options.onReset,
       opacity: this.options.opacity,
+      overlayColor: this.options.overlayColor,
       onOverlayClick: () => {
         // Perform the 'Next' operation when clicked outside the highlighted element
         if (this.options.overlayClickNext) {

--- a/src/lib/common/constants.ts
+++ b/src/lib/common/constants.ts
@@ -1,4 +1,5 @@
 export const OVERLAY_OPACITY = 0.75;
+export const OVERLAY_FILL_COLOR = "rgb(0,0,0)";
 export const OVERLAY_RADIUS = 5;
 export const OVERLAY_PADDING = 10;
 export const POPOVER_OFFSET = 10;

--- a/src/lib/core/overlay.ts
+++ b/src/lib/core/overlay.ts
@@ -74,10 +74,14 @@ class Overlay {
 
   constructor(options: OverlayOptions) {
     this.options = {
-      // padding: Padding default will come from outside, as it affects more then just the overlay
-      opacity: OVERLAY_OPACITY,
-      overlayColor: OVERLAY_FILL_COLOR,
       ...options,
+      opacity:
+        options.opacity === undefined ? OVERLAY_OPACITY : options.opacity,
+      overlayColor:
+        options.overlayColor === undefined
+          ? OVERLAY_FILL_COLOR
+          : options.overlayColor,
+      // padding: Padding default will come from outside, as it affects more then just the overlay
     };
   }
 

--- a/src/lib/core/overlay.ts
+++ b/src/lib/core/overlay.ts
@@ -38,7 +38,7 @@ export interface OverlayTopLevelOptions {
    */
   opacity?: number;
   /**
-   * Background color for the overlay element
+   * Fill color for the overlay
    * @default rgb(0,0,0)
    */
   overlayColor?: string;

--- a/src/lib/core/overlay.ts
+++ b/src/lib/core/overlay.ts
@@ -37,6 +37,11 @@ export interface OverlayTopLevelOptions {
    * @default 0.75
    */
   opacity?: number;
+  /**
+   * Background color for the overlay element
+   * @default rgb(0,0,0)
+   */
+  overlayColor?: string;
 }
 
 interface OverlayOptions
@@ -377,6 +382,7 @@ class Overlay {
       opacity: this.options.opacity,
       radius: definition.radius,
       animated: this.options.animate,
+      fillColor: this.options.overlayColor,
     };
 
     // mount svg if its not mounted already

--- a/src/lib/core/overlay.ts
+++ b/src/lib/core/overlay.ts
@@ -1,5 +1,5 @@
 import { BoardingSharedOptions } from "../boarding-types";
-import { OVERLAY_OPACITY } from "../common/constants";
+import { OVERLAY_FILL_COLOR, OVERLAY_OPACITY } from "../common/constants";
 import {
   assertVarIsNotFalsy,
   attachHighPrioClick,
@@ -76,6 +76,7 @@ class Overlay {
     this.options = {
       // padding: Padding default will come from outside, as it affects more then just the overlay
       opacity: OVERLAY_OPACITY,
+      overlayColor: OVERLAY_FILL_COLOR,
       ...options,
     };
   }


### PR DESCRIPTION
## Description

While migrating from `driver.js` to `boarding.js`, I noticed `boarding.js` lacked a convenient method for changing the background color of the overlay element, unlike in `driver.js`. I've added an `overlayColor` option to the `Boarding` class, to enable users easily set the background color of the overlay element without having to manually target its class.

## Changes

- Added `overlayColor` property to the `Boarding` class.
- Updated methods to use the new `overlayColor` property.
- Updated the relevant documentation to reflect this change

## Code Sample

```javascript
export const boarding = new Boarding({
  overlayColor: "yellow",
});
```

## Screenshot

![boarding.js overlay element with yellow background color](https://github.com/user-attachments/assets/8f89f43c-f177-4aca-8732-b8735824403a)



