### PR TITLE
Fix spelling of 'prefferedSide' in popover options; keep old spelling as an alternative.

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@ boarding.highlight({
         <div id="single-element-with-popover-position" class="section__example">
           <h4>Popover Positioning</h4>
           <p>
-            You can also, change the preffered position of the popover to be
+            You can also change the preferred position of the popover to be
             either
             <code>top</code>, <code>bottom</code>, <code>left</code>,
             <code>right</code>.
@@ -375,6 +375,12 @@ boarding.highlight({
             And for even more fine-grain control define the alignment of the
             popover to be either
             <code>start</code>, <code>center</code>, <code>end</code>
+          </p>
+          <p class="top-10">
+            <small
+              >Legacy <code>prefferedSide</code> still works for backward
+              compatibility.</small
+            >
           </p>
           <a
             href="#"
@@ -388,8 +394,8 @@ boarding.highlight({
   popover: {
     title: 'Title for the Popover',
     description: 'Description for it',
-    // prefferedPosition can be top, bottom, left, right
-    prefferedPosition: 'left',
+    // preferredSide can be top, bottom, left, right
+    preferredSide: 'left',
     // alignment can be start, center, end
     alignment: "start"
   }
@@ -526,7 +532,7 @@ boarding.defineSteps([
       className: 'first-step-popover-class',
       title: 'Title on Popover',
       description: 'Body of the popover',
-      prefferedPosition: 'left'
+      preferredSide: 'left'
     }
   },
   {
@@ -534,7 +540,7 @@ boarding.defineSteps([
     popover: {
       title: 'Title on Popover',
       description: 'Body of the popover',
-      prefferedPosition: 'top'
+      preferredSide: 'top'
     }
   },
   {
@@ -542,7 +548,7 @@ boarding.defineSteps([
     popover: {
       title: 'Title on Popover',
       description: 'Body of the popover',
-      prefferedPosition: 'right'
+      preferredSide: 'right'
     }
   },
 ]);
@@ -582,7 +588,7 @@ boarding.highlight({
   popover: {
     title: 'Title for the Popover',
     description: 'Description for it',
-    prefferedPosition: 'top', // can be `top`, `left`, `right`, `bottom`
+    preferredSide: 'top', // can be `top`, `left`, `right`, `bottom`
   }
 });
 </code></pre>

--- a/readme.md
+++ b/readme.md
@@ -118,7 +118,7 @@ Also, `title` and `description` can have HTML as well.
 
 ### Positioning the Popover – [Demo](https://josias-r.github.io/boarding.js#single-element-with-popover-position)
 
-By default, boarding automatically finds the suitable position for the popover and displays it. You can override it using `prefferedSide` and the `alignment` property.
+By default, boarding automatically finds the suitable position for the popover and displays it. You can override it using `preferredSide` and the `alignment` property (legacy `prefferedSide` is still supported).
 
 ```javascript
 const boarding = new Boarding();
@@ -127,8 +127,8 @@ boarding.highlight({
   popover: {
     title: "Title for the Popover",
     description: "Description for it",
-    // prefferedSide can be left, right, top, bottom
-    prefferedSide: "left",
+    // preferredSide can be left, right, top, bottom
+    preferredSide: "left",
     // alignment can be start, center, right
     alignment: "center",
   },
@@ -166,7 +166,7 @@ boarding.defineSteps([
       className: "first-step-popover-class",
       title: "Title on Popover",
       description: "Body of the popover",
-      prefferedSide: "left",
+      preferredSide: "left",
     },
   },
   {
@@ -174,7 +174,7 @@ boarding.defineSteps([
     popover: {
       title: "Title on Popover",
       description: "Body of the popover",
-      prefferedSide: "top",
+      preferredSide: "top",
     },
   },
   {
@@ -182,7 +182,7 @@ boarding.defineSteps([
     popover: {
       title: "Title on Popover",
       description: "Body of the popover",
-      prefferedSide: "right",
+      preferredSide: "right",
     },
   },
 ]);
@@ -209,7 +209,7 @@ boarding.defineSteps([
     popover: {
       title: "Title on Popover",
       description: "Body of the popover",
-      prefferedSide: "left",
+      preferredSide: "left",
     },
   },
   {
@@ -217,7 +217,7 @@ boarding.defineSteps([
     popover: {
       title: "Title on Popover",
       description: "Body of the popover",
-      prefferedSide: "top",
+      preferredSide: "top",
     },
     onNext: () => {
       // Prevent moving to the next step
@@ -235,7 +235,7 @@ boarding.defineSteps([
     popover: {
       title: "Title on Popover",
       description: "Body of the popover",
-      prefferedSide: "right",
+      preferredSide: "right",
     },
   },
 ]);
@@ -308,7 +308,7 @@ const stepDefinition = {
     closeBtnText: "Close", // Text on the close button
     nextBtnText: "Next", // Next button text
     prevBtnText: "Previous", // Previous button text
-    preferredSide: "top", // Preffered side on which the popover should render of the HighlightElement
+    preferredSide: "top", // Preferred side on which the popover should render of the HighlightElement
     alignment: "start", // Alignment of the popover on the side it gets renderd on
     // Make changes to the actual popoverElements once they get rendered.
     onPopoverRender: (el) => {

--- a/src/lib/boarding.ts
+++ b/src/lib/boarding.ts
@@ -81,6 +81,9 @@ class Boarding {
       ...defaultOptions
     } = { ...options };
 
+    const normalizedPreferredSide =
+      defaultOptions.preferredSide ?? defaultOptions.prefferedSide;
+
     this.options = {
       strictClickHandling,
       animate,
@@ -90,6 +93,7 @@ class Boarding {
       allowClose,
       keyboardControl,
       overlayClickNext,
+      preferredSide: normalizedPreferredSide ?? defaultOptions.preferredSide,
       ...defaultOptions,
     };
 
@@ -638,6 +642,10 @@ class Boarding {
 
     let popover: Popover | null = null;
     if (currentStep.popover?.title) {
+      const preferredSide =
+        currentStep.popover.preferredSide ??
+        currentStep.popover.prefferedSide ??
+        this.options.preferredSide;
       const mergedClassNames = [
         this.options.className,
         currentStep.popover.className,
@@ -658,8 +666,7 @@ class Boarding {
         title: currentStep.popover.title,
         description: currentStep.popover.description,
         // hybrid options
-        prefferedSide:
-          currentStep.popover.prefferedSide || this.options.prefferedSide,
+        preferredSide,
         alignment: currentStep.popover.alignment || this.options.alignment,
         showButtons:
           currentStep.popover.showButtons === undefined

--- a/src/lib/core/popover.ts
+++ b/src/lib/core/popover.ts
@@ -89,7 +89,12 @@ export interface PopoverHybridOptions {
    */
   className?: string;
   /**
-   * Preffered side to render the popover
+   * Preferred side to render the popover
+   */
+  preferredSide?: Sides;
+  /**
+   * Preferred side to render the popover (backwards-compatible alias)
+   * @deprecated Use `preferredSide` instead.
    */
   prefferedSide?: Sides;
   /**
@@ -167,8 +172,11 @@ export default class Popover {
     startBtnText = "Next &rarr;",
     nextBtnText = "Next &rarr;",
     prevBtnText = "&larr; Previous",
+    preferredSide,
+    prefferedSide,
     ...options
   }: PopoverOptions) {
+    const resolvedPreferredSide = preferredSide ?? prefferedSide;
     this.options = {
       showButtons,
       disableButtons,
@@ -179,6 +187,7 @@ export default class Popover {
       startBtnText,
       nextBtnText,
       prevBtnText,
+      preferredSide: resolvedPreferredSide,
       ...options,
     };
   }
@@ -276,6 +285,7 @@ export default class Popover {
    */
   private setPosition() {
     assertVarIsNotFalsy(this.highlightElement);
+    const preferredSide = this.options.preferredSide;
 
     const customPadding = this.highlightElement.getCustomPadding();
 
@@ -284,7 +294,7 @@ export default class Popover {
       this,
       checkOptionalValue(this.options.padding, customPadding),
       this.options.offset
-    ).setBestPosition(this.options.alignment, this.options.prefferedSide);
+    ).setBestPosition(this.options.alignment, preferredSide);
   }
 
   /**

--- a/src/lib/core/smart-position.ts
+++ b/src/lib/core/smart-position.ts
@@ -197,10 +197,10 @@ class SmartPosition {
     right?: number;
   } {
     let foundSideResult: SideCheckResult | "none";
-    // check if prefferd side is optimal
+    // check if preferred side is optimal
     if (preferredSide) {
       foundSideResult = this.checkIfSideOptimal(preferredSide);
-      // if preffered side was not optimal -> check all sides the standard way
+      // if preferred side was not optimal -> check all sides the standard way
       if (!foundSideResult.isOptimal) {
         foundSideResult = this.findOptimalSide();
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -17,7 +17,7 @@ document.addEventListener("DOMContentLoaded", function () {
         description:
           "This is just one use-case, make sure to check out the rest of the docs below.",
         nextBtnText: "Okay, Start!",
-        prefferedSide: "left",
+        preferredSide: "left",
         alignment: "center",
       },
     },
@@ -43,7 +43,7 @@ document.addEventListener("DOMContentLoaded", function () {
         title: "Let's talk features",
         description:
           "You may leave your mouse and use the <strong>arrow keys</strong> to move next and back or <strong>escape key</strong> anytime to close this",
-        prefferedSide: "bottom",
+        preferredSide: "bottom",
       },
     },
     {
@@ -60,7 +60,7 @@ document.addEventListener("DOMContentLoaded", function () {
         title: "Feature Introductions",
         description:
           "With it's powerful API you can use it to make programmatic or user driven feature introductions",
-        prefferedSide: "bottom",
+        preferredSide: "bottom",
       },
     },
     {
@@ -69,7 +69,7 @@ document.addEventListener("DOMContentLoaded", function () {
         title: "Focus Shifters",
         description:
           "If some element or part of the page needs user's interaction, you can just call the highlight method. Boarding will take care of driving the user there",
-        prefferedSide: "bottom",
+        preferredSide: "bottom",
       },
     },
     {
@@ -78,7 +78,7 @@ document.addEventListener("DOMContentLoaded", function () {
         title: "Highly Customizable",
         description:
           "Boarding has a powerful API allowing you to customize the experience as much as you can.",
-        prefferedSide: "bottom",
+        preferredSide: "bottom",
       },
     },
     {
@@ -87,7 +87,7 @@ document.addEventListener("DOMContentLoaded", function () {
         title: "User Friendly",
         description:
           "Your users can control it with the arrow keys on keyboard, or escape to close it",
-        prefferedSide: "bottom",
+        preferredSide: "bottom",
       },
     },
     {
@@ -208,7 +208,7 @@ document.addEventListener("DOMContentLoaded", function () {
           showButtons: false,
           title: "Did you know?",
           description: "You can add HTML in title or description also!",
-          prefferedSide: "top",
+          preferredSide: "top",
         },
       });
     });
@@ -228,7 +228,7 @@ document.addEventListener("DOMContentLoaded", function () {
           showButtons: false,
           title: "Did you know?",
           description: "You can add HTML in title or description also!",
-          prefferedSide: "top",
+          preferredSide: "top",
         },
       });
     });
@@ -245,18 +245,18 @@ document.addEventListener("DOMContentLoaded", function () {
 
     let id = (e.target as HTMLElement).id;
     let alignment = (e.target as HTMLElement).dataset.alignment;
-    let preferredside = (e.target as HTMLElement).dataset.preferredside;
+    let preferredSide = (e.target as HTMLElement).dataset.preferredside;
 
     positionBtnsBoarding.highlight({
       element: id
         ? `#${id}`
-        : `#position-btns [data-alignment="${alignment}"][data-preferredside="${preferredside}"]`,
+        : `#position-btns [data-alignment="${alignment}"][data-preferredside="${preferredSide}"]`,
       popover: {
         showButtons: false,
         title: "Did you know?",
         description: "You can add HTML in title or description also!",
         alignment: alignment as any,
-        prefferedSide: preferredside as any,
+        preferredSide: preferredSide as any,
       },
     });
   });
@@ -277,7 +277,7 @@ document.addEventListener("DOMContentLoaded", function () {
           showButtons: false,
           title: "<em>Tags</em> in title or <u>body</u>",
           description: "Body can also have <strong>html tags</strong>!",
-          prefferedSide: "top",
+          preferredSide: "top",
         },
       });
     });
@@ -300,7 +300,7 @@ document.addEventListener("DOMContentLoaded", function () {
         popover: {
           title: "Title for the Popover",
           description: "Description for it",
-          prefferedSide: "top", // can be `top`, `left`, `right`, `bottom`
+          preferredSide: "top", // can be `top`, `left`, `right`, `bottom`
         },
       });
     });
@@ -350,7 +350,7 @@ document.addEventListener("DOMContentLoaded", function () {
   /////////////////////////////////////////////
   const singleNoClose = new Boarding({
     allowClose: false,
-    prefferedSide: "top",
+    preferredSide: "top",
   });
 
   singleNoClose.defineSteps([
@@ -366,7 +366,7 @@ document.addEventListener("DOMContentLoaded", function () {
       popover: {
         title: "Title on Popover",
         description: "Body of the popover",
-        prefferedSide: "top",
+        preferredSide: "top",
       },
     },
   ]);
@@ -389,7 +389,7 @@ document.addEventListener("DOMContentLoaded", function () {
         className: "first-step-popover-class",
         title: "Title on Popover",
         description: "Body of the popover",
-        prefferedSide: "top",
+        preferredSide: "top",
       },
     },
     {
@@ -397,7 +397,7 @@ document.addEventListener("DOMContentLoaded", function () {
       popover: {
         title: "Title on Popover",
         description: "Body of the popover",
-        prefferedSide: "bottom",
+        preferredSide: "bottom",
       },
     },
     {
@@ -405,7 +405,7 @@ document.addEventListener("DOMContentLoaded", function () {
       popover: {
         title: "Title on Popover",
         description: "Body of the popover",
-        prefferedSide: "top",
+        preferredSide: "top",
       },
     },
     {
@@ -413,7 +413,7 @@ document.addEventListener("DOMContentLoaded", function () {
       popover: {
         title: "Title on Popover",
         description: "Body of the popover",
-        prefferedSide: "top",
+        preferredSide: "top",
       },
     },
     {
@@ -421,7 +421,7 @@ document.addEventListener("DOMContentLoaded", function () {
       popover: {
         title: "Title on Popover",
         description: "Body of the popover",
-        prefferedSide: "top",
+        preferredSide: "top",
       },
     },
   ]);


### PR DESCRIPTION
Keeps legacy support for old spelling with a deprecation notice.