### PR TITLE
fix: remove next branch release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ name: Release CI
 
 on:
   push:
-    branches: [main, next]
+    branches: [main]
 
 permissions:
   contents: write # to be able to publish a GitHub release


### PR DESCRIPTION
Due to an issue with semantic release npm and the new npm oidc, re-tagging is broken. I decided to remove the next branch flow, as this project is small anyways.